### PR TITLE
Fix: Handle IPv6 Stack Unavailability in Traceroute Functionality (Generated by Ana - AI SDE) 

### DIFF
--- a/connvitals/traceroute.py
+++ b/connvitals/traceroute.py
@@ -39,17 +39,20 @@ class Tracer():
 		self.maxHops = maxHops
 
 		# A bunch of stuff needs to be tweaked if we're using IPv6
-		if host.family is socket.AF_INET6:
-			# BTW, this doesn't actually work. The RFCs for IPv6 don't define
-			# the behaviour of raw sockets - which are heavily utilized by
-			# `connvitals`. One of these days, I'll have to implement it using
-			# raw ethernet frames ...
-
-			self.receiver = socket.socket(family=host.family,
-			                              type=socket.SOCK_RAW,
-			                              proto=socket.IPPROTO_ICMPV6)
-			self.setTTL = self.setIPv6TTL
-			self.isMyTraceResponse = self.isMyIPv6TraceResponse
+ 		if host.family is socket.AF_INET6:
+			if socket.has_ipv6:
+				# BTW, this doesn't actually work. The RFCs for IPv6 don't define
+				# the behaviour of raw sockets - which are heavily utilized by
+				# `connvitals`. One of these days, I'll have to implement it using
+				# raw ethernet frames ...
+		
+				self.receiver = socket.socket(family=host.family,
+							      type=socket.SOCK_RAW,
+							      proto=socket.IPPROTO_ICMPV6)
+				self.setTTL = self.setIPv6TTL
+				self.isMyTraceResponse = self.isMyIPv6TraceResponse
+			else:
+				raise EnvironmentError("IPv6 stack is not available on this system.")
 
 		else:
 			self.receiver = socket.socket(family=host.family,


### PR DESCRIPTION
### Description

This pull request addresses an issue where the traceroute functionality would fail on systems without an available IPv6 stack. 

Specifically, the `Tracer` class in `connvitals/traceroute.py` now gracefully handles the absence of an IPv6 stack by checking for its availability before attempting to create IPv6 sockets. If the stack is not available, an `EnvironmentError` is raised, preventing crashes and providing a more informative error message.

### Changes

- Added a check for `socket.has_ipv6` in the `Tracer.__init__` method before creating IPv6 sockets.
- If an IPv6 stack is not available, an `EnvironmentError` is raised with a message indicating that the IPv6 stack is not available on the system.

Fixes [Issue 9](https://github.com/Comcast/connvitals/issues/9)

This patch was generated by [Ana - AI SDE](https://openana.ai/), an AI-powered software development assistant. 
